### PR TITLE
Fix tool-call leakage, premature completion, and modal layout squish

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -94,16 +94,21 @@ export default async function RootLayout({
     return (
         <ClerkProvider>
             <html lang="en">
+                {/* The container classes live on a wrapper div, NOT on body:
+                    dialog scroll-locking injects margin/padding styles onto
+                    body, which fights mx-auto and squishes the whole page */}
                 <body
-                    className={`${openSans.variable} ${schibstedGrotesk.variable} ${nunitoSans.variable} antialiased container mx-auto max-w-7xl`}
+                    className={`${openSans.variable} ${schibstedGrotesk.variable} ${nunitoSans.variable} antialiased`}
                     suppressHydrationWarning={true}
                 >
-                    <NextIntlClientProvider>
-                        <Header></Header>
-                        <Chatbot></Chatbot>
-                        {children}
-                        <Analytics />
-                    </NextIntlClientProvider>
+                    <div className="container mx-auto max-w-7xl">
+                        <NextIntlClientProvider>
+                            <Header></Header>
+                            <Chatbot></Chatbot>
+                            {children}
+                            <Analytics />
+                        </NextIntlClientProvider>
+                    </div>
                 </body>
             </html>
         </ClerkProvider>

--- a/lib/actions/conversation.actions.ts
+++ b/lib/actions/conversation.actions.ts
@@ -26,6 +26,21 @@ function setLessonObjectiveToTrue({
   return objectiveIndex;
 }
 
+// The model occasionally writes its tool calls out as pseudo-code text
+// (e.g. "tool_code print(setLessonObjectiveToTrue(0))") instead of using the
+// function-calling mechanism — strip those artifacts so they never reach the
+// chat or the TTS voice. Patterns stay anchored to the tool name and known
+// markers so legitimate tutor speech is untouched.
+function stripToolSyntax(text: string): string {
+  return text
+    .replace(
+      /```[\s\S]*?```|^[ \t]*(?:tool_code|tool_call)\b.*$|(?:tool_code|tool_call)[:\s]*|(?:print\s*\(\s*)?setLessonObjectiveToTrue\s*\(\s*(?:index\s*=\s*)?\d*\s*\)\)?/gim,
+      ""
+    )
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
 export async function getResponse(
   audioUrlBase64: string,
   instructions: string
@@ -81,39 +96,37 @@ export async function getResponse(
         ],
       },
     });
-    let objectiveIndex = undefined;
-
-    // Check for function calls in the response
-    if (response.functionCalls && response.functionCalls.length > 0) {
-      const functionCall = response.functionCalls[0]; // Assuming one function call
+    // Collect every function call — the model can emit several in one turn,
+    // and dropping any of them desyncs its beliefs from the stored progress
+    const objectiveIndices: number[] = [];
+    for (const functionCall of response.functionCalls ?? []) {
       if (functionCall.args) {
-        objectiveIndex = setLessonObjectiveToTrue(
+        const objectiveIndex = setLessonObjectiveToTrue(
           functionCall.args as { objectiveIndex: number }
         );
+        if (objectiveIndex !== null && objectiveIndex !== undefined) {
+          objectiveIndices.push(objectiveIndex);
+        }
       } else {
         console.warn("Function call found but no args provided");
       }
     }
 
-    let transcriptionSystem = response.text ?? "";
+    let transcriptionSystem = stripToolSyntax(response.text ?? "");
 
     // If the model made a tool call but returned no reply text, ask it once
     // (without tools) for a short acknowledgement that continues the lesson
-    if (
-      objectiveIndex !== undefined &&
-      objectiveIndex !== null &&
-      !transcriptionSystem.trim()
-    ) {
+    if (objectiveIndices.length > 0 && !transcriptionSystem.trim()) {
       try {
         const followUp = await ai.models.generateContent({
           model: "gemini-3.1-flash-lite",
           contents:
-            "The student just successfully demonstrated a lesson objective. Briefly acknowledge their success and continue the lesson by asking them the next question.",
+            "The student just successfully demonstrated a lesson objective and it has already been recorded. Do NOT call any function or tool, and never write code, code fences, 'tool_code', 'tool_call', or 'print(' in your reply — natural spoken English only. Briefly acknowledge their success and continue the lesson by asking them the next question.",
           config: {
             systemInstruction: instructions,
           },
         });
-        transcriptionSystem = followUp.text ?? "";
+        transcriptionSystem = stripToolSyntax(followUp.text ?? "");
       } catch (followUpError) {
         console.error("Error in follow-up response:", followUpError);
       }
@@ -145,7 +158,7 @@ export async function getResponse(
       success: true,
       audioBase64Response: audioBase64,
       systemTranscription: transcriptionSystem,
-      objectiveIndex: objectiveIndex,
+      objectiveIndices: objectiveIndices,
     };
   } catch (error) {
     console.error("Error in getResponse:", error);
@@ -218,7 +231,7 @@ export async function getInitialResponse(instructions: string) {
       },
     });
 
-    const transcriptionSystem = response.text ?? "";
+    const transcriptionSystem = stripToolSyntax(response.text ?? "");
 
     if (!transcriptionSystem.trim()) {
       return {
@@ -384,22 +397,19 @@ export async function processAudioMessage({
       };
     }
 
-    // update objectives if there was a tool call used by the model
+    // update objectives for every tool call the model made this turn
     const currentObjectivesMet = [...currentProgress.objectivesMet]; // Create new array
 
-    if (
-      audioResponse.objectiveIndex !== undefined &&
-      audioResponse.objectiveIndex !== null
-    ) {
+    for (const objectiveIndex of audioResponse.objectiveIndices ?? []) {
       // Validate index bounds
       if (
-        audioResponse.objectiveIndex >= 0 &&
-        audioResponse.objectiveIndex < currentObjectivesMet.length
+        objectiveIndex >= 0 &&
+        objectiveIndex < currentObjectivesMet.length
       ) {
-        currentObjectivesMet[audioResponse.objectiveIndex] = true;
+        currentObjectivesMet[objectiveIndex] = true;
       } else {
         console.warn(
-          `Invalid objective index: ${audioResponse.objectiveIndex}. Valid range: 0-${currentObjectivesMet.length - 1}`
+          `Invalid objective index: ${objectiveIndex}. Valid range: 0-${currentObjectivesMet.length - 1}`
         );
       }
     }

--- a/lib/actions/conversation.actions.ts
+++ b/lib/actions/conversation.actions.ts
@@ -12,6 +12,10 @@ import {
 const OBJECTIVE_COMPLETE_FALLBACK =
   "Great work! You've got that down. Shall we keep going with the next part of the lesson?";
 
+// Fallback conclusion for the turn that completes the final objective
+const LESSON_COMPLETE_FALLBACK =
+  "Fantastic work today! You've completed every part of this lesson — congratulations, and see you in the next one!";
+
 function setLessonObjectiveToTrue({
   objectiveIndex,
 }: {
@@ -43,7 +47,8 @@ function stripToolSyntax(text: string): string {
 
 export async function getResponse(
   audioUrlBase64: string,
-  instructions: string
+  instructions: string,
+  currentObjectivesMet: boolean[]
 ) {
   const openai = new OpenAI();
   const geminiKey = process.env.GEMINI_KEY;
@@ -114,9 +119,44 @@ export async function getResponse(
 
     let transcriptionSystem = stripToolSyntax(response.text ?? "");
 
-    // If the model made a tool call but returned no reply text, ask it once
-    // (without tools) for a short acknowledgement that continues the lesson
-    if (objectiveIndices.length > 0 && !transcriptionSystem.trim()) {
+    // Does this turn's tool call complete the final objective? The model
+    // generated its reply against the PRE-completion objective list (which
+    // told it to keep teaching), so the reply for this turn must be replaced
+    // with a proper conclusion instead of another practice question
+    const objectivesAfterCalls = [...currentObjectivesMet];
+    for (const objectiveIndex of objectiveIndices) {
+      if (objectiveIndex >= 0 && objectiveIndex < objectivesAfterCalls.length) {
+        objectivesAfterCalls[objectiveIndex] = true;
+      }
+    }
+    const lessonJustCompleted =
+      objectiveIndices.length > 0 &&
+      objectivesAfterCalls.length > 0 &&
+      objectivesAfterCalls.every((met) => met) &&
+      !currentObjectivesMet.every((met) => met);
+
+    if (lessonJustCompleted) {
+      try {
+        const conclusion = await ai.models.generateContent({
+          model: "gemini-3.1-flash-lite",
+          contents:
+            "The student has now completed EVERY lesson objective — the lesson is finished. Give a warm, brief conclusion: congratulate them on what they practised today and say goodbye. Do NOT ask any question, do NOT start new practice, and never write code, code fences, 'tool_code', 'tool_call', or 'print(' in your reply — natural spoken English only.",
+          config: {
+            systemInstruction: instructions,
+          },
+        });
+        transcriptionSystem = stripToolSyntax(conclusion.text ?? "");
+      } catch (conclusionError) {
+        console.error("Error in conclusion response:", conclusionError);
+        transcriptionSystem = "";
+      }
+
+      if (!transcriptionSystem.trim()) {
+        transcriptionSystem = LESSON_COMPLETE_FALLBACK;
+      }
+    } else if (objectiveIndices.length > 0 && !transcriptionSystem.trim()) {
+      // The model made a tool call but returned no reply text — ask it once
+      // (without tools) for a short acknowledgement that continues the lesson
       try {
         const followUp = await ai.models.generateContent({
           model: "gemini-3.1-flash-lite",
@@ -375,7 +415,7 @@ export async function processAudioMessage({
     // them concurrently
     const [transcriptionUser, audioResponse] = await Promise.all([
       getUserTranscription(audioBase64),
-      getResponse(audioBase64, instructions),
+      getResponse(audioBase64, instructions, currentProgress.objectivesMet),
     ]);
 
     const userTranscription = transcriptionUser.userTranscription ?? "";

--- a/lib/actions/conversation.actions.ts
+++ b/lib/actions/conversation.actions.ts
@@ -38,10 +38,11 @@ function setLessonObjectiveToTrue({
 function stripToolSyntax(text: string): string {
   return text
     .replace(
-      /```[\s\S]*?```|^[ \t]*(?:tool_code|tool_call)\b.*$|(?:tool_code|tool_call)[:\s]*|(?:print\s*\(\s*)?setLessonObjectiveToTrue\s*\(\s*(?:index\s*=\s*)?\d*\s*\)\)?/gim,
+      /```[\s\S]*?```|```[\s\S]*$|^[ \t]*(?:tool_code|tool_call)\b.*$|(?:tool_code|tool_call)[:\s]*|(?:print\s*\(\s*)?setLessonObjectiveToTrue\s*\([^)]*\)\)?/gim,
       ""
     )
-    .replace(/\s{2,}/g, " ")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
 
@@ -349,18 +350,17 @@ export async function processInitialMessage({
       };
     }
 
-    // Persist only the tutor's greeting
-    const newConvoHistory = [
-      {
-        role: "System",
-        message: audioResponse.systemTranscription ?? "",
-      },
-    ];
-
     const updatedLessonProgress = await updateLessonProgress({
       lessonIndex: lessonProgress.lessonIndex,
       objectivesMet: currentProgress.objectivesMet,
-      convoHistory: newConvoHistory,
+      // Persist only the tutor's greeting, appended atomically so a slow
+      // concurrent tab can't wipe messages written after our empty check
+      appendMessages: [
+        {
+          role: "System",
+          message: audioResponse.systemTranscription ?? "",
+        },
+      ],
     });
 
     return {

--- a/utils/conversation_config.ts
+++ b/utils/conversation_config.ts
@@ -8,13 +8,13 @@ Instructions:
 - The whole conversation MUST be focused around teaching this lesson. If the student begins talking about something unrelated to the lesson, gently guide them back to the lesson.
 
 CRITICAL PROGRESSION RULE:
-Your primary directive is to continuously advance the lesson. EVERY single response must end with a question, prompt, or challenge that moves the student forward. You are FORBIDDEN from ending any response with just praise, statements, or acknowledgments without follow-up action.
+Your primary directive is to keep the lesson moving at a steady, learner-friendly pace. EVERY single response must end with a question, prompt, or challenge that moves the student forward. You are FORBIDDEN from ending any response with just praise, statements, or acknowledgments without follow-up action. Moving forward means the NEXT practice step - it does NOT mean rushing to mark objectives complete. A good lesson takes many exchanges; each objective deserves several rounds of practice.
 
 Guidance:
 1. Responses are ideally 2-3 sentences.
 2. You are LEADING the conversation with a PROGRESSION-FOCUSED approach. Your responses should ALWAYS drive towards completing lesson objectives:
-    - When a user demonstrates competency in a lesson objective, immediately call the setLessonObjectiveToTrue function, then MUST continue by moving toward the next incomplete objective.
-    - EVERY response should end with a question or prompt that advances the lesson toward completing remaining objectives.
+    - Work on ONE objective at a time, in order. Give the student varied practice on it across multiple turns before you consider it demonstrated.
+    - EVERY response should end with a question or prompt that advances the current objective (or begins the next one once the current one is COMPLETED in the "Objectives Met" section).
     - After acknowledging correct answers, IMMEDIATELY guide the conversation toward the next learning goal.
     - Never let the conversation stagnate - always push forward through the lesson content.
     - If you find yourself wanting to just say "Good job!" or similar praise, you MUST immediately follow it with "Now let's try..." or "Can you show me..." or "What would you say if..."
@@ -33,23 +33,22 @@ Guidance:
             3. "Excellent use of polite language! Now imagine you're at a hawker center and want to order. What would you say to get the uncle's attention?" [reinforces learning + applies to new context]
             4. "Good! Now let's try using that in a different situation. What if you needed to ask for help at the post office?" [builds on success and advances to next scenario]
 
-3. MANDATORY LESSON PROGRESSION STRATEGY:
-    - Always check which objectives are still "TO BE DONE" 
-    - After any user success, immediately guide toward the next incomplete objective
+3. LESSON PACING STRATEGY:
+    - Check the "Objectives Met" section: focus your teaching on the FIRST objective that is still "TO BE DONE".
+    - Each objective needs its OWN, DIFFERENT demonstration - the same single user sentence can never count for more than one objective. A greeting shows greeting skill; it does not show conversation skill or polite-phrase skill.
+    - An objective normally needs at least 2 relevant, successful user turns before it is demonstrated. Only mark it after a single turn if that turn is an unmistakable, complete demonstration of that specific skill.
     - Use bridging phrases like: "Great! Now let's try...", "Perfect! Next, how would you...", "Excellent! Let's practice..."
-    - Never give standalone praise - always couple praise with forward movement
-    - Think: "What's the next thing they need to learn?" after every interaction
+    - Never give standalone praise - always couple praise with the next practice prompt.
 
 4. Tool Call Decision Making:
-    - Make tool calls promptly when you observe clear demonstration of a lesson objective
-    - Don't wait for "perfect" responses - if the user shows understanding of the core skill, mark it complete
-    - You can ask 1-2 follow-up questions to confirm understanding, but avoid over-testing
-    - After making a tool call, IMMEDIATELY continue teaching the next incomplete objective - never pause or end with just praise
+    - Call setLessonObjectiveToTrue only when the CURRENT objective has been genuinely demonstrated per the pacing rules above (usually 2+ relevant user turns).
+    - You may call setLessonObjectiveToTrue AT MOST ONCE per turn. Never mark two or more objectives in the same response, even if you believe several were demonstrated - mark the earliest one and keep practicing the others in later turns.
+    - Don't demand perfection - small grammar slips are fine if the core skill is shown - but do require real, repeated use of the skill, not a polite one-liner.
+    - After making a tool call, continue teaching the next incomplete objective in the same reply - never pause or end with just praise.
 
 5. PROGRESSION ENFORCEMENT: After every user response, you must:
-   - Assess if they demonstrated any objective competency (if yes, mark complete)
-   - Identify which objectives are still "TO BE DONE"
-   - Guide the conversation toward the next incomplete objective
+   - Assess whether the CURRENT objective (first "TO BE DONE") has now met the evidence bar; if yes, mark it complete (one tool call max)
+   - Otherwise, give the student another varied practice prompt for that same objective
    - NEVER end responses with just acknowledgment - always include forward momentum
 
 6. DO NOT directly mention lesson objectives, completion status, or ask users about their progress. Make these assessments independently while driving forward.
@@ -61,19 +60,26 @@ Context:
 2. Do not talk about other countries, keep every discussion about Singapore in terms of culture and context.
 
 Tool Call Instructions:
-- **CRITICAL**: Call the setLessonObjectiveToTrue function IMMEDIATELY when you observe the user successfully demonstrate a lesson objective skill
+- Call the setLessonObjectiveToTrue function when the user has genuinely demonstrated a lesson objective skill (see the pacing rules: usually 2+ relevant user turns; a single turn only if it is an unmistakable, complete demonstration of that exact skill)
+- AT MOST ONE setLessonObjectiveToTrue call per turn. Other objectives, even if they look close, must wait for their own demonstration in later turns.
+- Each objective requires a DISTINCT demonstration. As a guide: an objective about using a phrase type (e.g. greetings, please/thank you) needs the user to produce those phrases themselves, correctly, in context; an objective about holding a conversation needs a back-and-forth of several turns where the user both responds and asks; an objective about comfort/confidence needs repeated successful use across different prompts, not one line.
 - Look for practical application and understanding, not just repetition or memorization
-- You can mark objectives complete whenever the user shows genuine competency - don't wait for perfect responses
 - Pass the exact index of the completed objective (0 for first objective, 1 for second, 2 for third, etc.)
-- **IMPORTANT**: Make the tool call BEFORE you respond to the user - this ensures the UI updates correctly
+- Make the tool call through the function-calling mechanism ONLY. NEVER write the function name, code, JSON, or any tool-call syntax in your spoken reply text - the reply must read as natural teacher speech.
 - **NEVER respond with only a function call** - every turn that includes a tool call MUST also include your spoken reply text, briefly acknowledging the success and asking the next question
 - Continue teaching naturally after making the tool call - don't mention that you've marked anything complete
 - Do not mention tool calls, progress tracking, or ask permission to mark objectives complete
-- If unsure about completion, ask ONE targeted follow-up question to assess, then decide and call the tool
+- If unsure about completion, ask ONE targeted follow-up question to assess, then decide on the next turn
 - **INDEX MAPPING**: Always use 0-based indexing: First objective = 0, Second objective = 1, Third objective = 2
 
-Conclusion: 
-When ALL lesson objectives are completed, conclude warmly and say goodbye. Check the "Objectives Met" section to confirm all objectives show as COMPLETED.
+Objective Status Source of Truth:
+- The "Objectives Met" section below is the ONLY source of truth for progress. Making a tool call does NOT complete an objective by itself - an objective counts as done only when it shows COMPLETED in that section on a later turn.
+- Never assume, state, or act as if an objective is finished unless it is marked COMPLETED there.
+
+Conclusion:
+- You may conclude the lesson ONLY when EVERY objective in the "Objectives Met" section below is marked COMPLETED. If even one objective still shows TO BE DONE, you MUST keep teaching and end with a question - never say the lesson is complete, never say goodbye.
+- Marking an objective this turn does not make the lesson complete; the remaining TO BE DONE objectives still need their own practice in future turns.
+- When all objectives truly show COMPLETED, conclude warmly and say goodbye.
 
 Personality:
 - Be upbeat and genuine


### PR DESCRIPTION
## Summary

Follow-up fixes from live testing after #53 was merged:

### Tool-call text leakage + premature lesson completion (632fc1d)
- Gemini sometimes wrote its tool calls as pseudo-code text ("tool_code print(setLessonObjectiveToTrue(0))...") which was displayed in chat and read aloud by TTS. Root-caused via live API reproduction: the follow-up call (fired when a tool-call turn returns no text) reused a prompt demanding immediate tool calls while providing no tools. Fixed the follow-up prompt (measured 0/15 leaks + 0/15 empty replies, vs 2/25 and 22/25 before) and added a `stripToolSyntax` sanitizer before TTS/DB as defense in depth.
- All `functionCalls` are now handled instead of only `[0]` — multiple completions per turn no longer silently desync the model's beliefs from stored progress.
- Rewrote the system prompt's pacing rules: one objective at a time in order, max one completion per turn, evidence bar of usually 2+ relevant user turns, distinct demonstration per objective, the Objectives Met list is the sole source of truth, and concluding is forbidden while any objective is TO BE DONE. A/B tested live: a bare "Hi, how are you today?" marked an objective 4/4 runs on the old prompt, 0/4 on the new one — while a genuinely earned objective is still marked 4/4.

### Proper conclusion on the final turn (6b6b2be)
The model writes its reply against the pre-completion objective list, so the turn that completed the last objective kept teaching and asked another question underneath the Lesson Complete modal. When a turn's tool calls bring all objectives to complete, the reply is now a generated conclusion (congratulations + goodbye, no question) with a hardcoded fallback.

### CodeRabbit findings (d85db1f)
Hardened the sanitizer (named/arbitrary args, unterminated code fences, paragraph structure preserved) and the greeting is appended atomically instead of replacing conversation history.

### Modal layout squish (19389aa)
`container mx-auto max-w-7xl` lived on `<body>`; Radix Dialog's scroll lock injects margin/padding onto body, which fought the auto margins and squished the whole page whenever a modal opened. Container moved to a wrapper div.

## Test plan
- `npx tsc --noEmit` and `npm run build` pass at every commit
- Sanitizer verified against the exact leaked string from the live incident plus edge cases (named args, unterminated fences, clean replies untouched)
- Prompt changes A/B tested against the live Gemini API (repro + anti-regression scenarios)
- CodeRabbit run after each change; final review clean (0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)