### PR TITLE
Isolate simple performance cleanups

### DIFF
--- a/app/[locale]/(root)/about/page.tsx
+++ b/app/[locale]/(root)/about/page.tsx
@@ -38,7 +38,11 @@ export default function AboutPage() {
                                 <div className="absolute top-1/2 left-2 w-6 h-6 bg-primary/12 rotate-45 group-hover:bg-primary/20 transition-colors duration-300"></div>
                                 <div className="absolute bottom-4 left-8 w-10 h-10 bg-primary/10 rounded-lg -rotate-6 group-hover:bg-primary/18 transition-colors duration-300"></div>
 
-                                <div className="relative mx-auto mb-6">
+                                {/* w-full is load-bearing: CardHeader is a grid,
+                                    so with only an absolutely-positioned fill
+                                    image inside, this wrapper would otherwise
+                                    shrink-wrap to zero width */}
+                                <div className="relative w-full mx-auto mb-6">
                                     <div className="relative w-full aspect-[3/3] rounded-xl overflow-hidden border-2 border-primary/20 group-hover:border-primary/40 transition-all duration-300 bg-gradient-to-br from-primary/5 to-primary/10">
                                         <Image
                                             src={person.image}

--- a/app/[locale]/(root)/contact/page.tsx
+++ b/app/[locale]/(root)/contact/page.tsx
@@ -1,33 +1,8 @@
-"use client";
-// Later turn this into component to send the use client down
-import { useRef } from "react";
-import emailjs from "@emailjs/browser";
 import { useTranslations } from "next-intl";
-export default function ContactForm() {
-    const form = useRef<HTMLFormElement>(null);
-    const t = useTranslations("contactUs");
-    const sendEmail = (e: React.FormEvent) => {
-        e.preventDefault();
-        if (!form.current) return;
+import ContactForm from "@/components/contact/ContactForm";
 
-        emailjs
-            .sendForm(
-                process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID!,
-                process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID!,
-                form.current,
-                process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY!,
-            )
-            .then(
-                () => {
-                    alert("Message sent! 🎉");
-                    form.current?.reset();
-                },
-                (error) => {
-                    alert("Failed to send. 😞");
-                    console.error(error);
-                },
-            );
-    };
+export default function ContactPage() {
+    const t = useTranslations("contactUs");
 
     return (
         <div className="flex min-h-screen flex-col justify-center px-5 pt-20 font-body text-ink md:flex-row">
@@ -42,35 +17,7 @@ export default function ContactForm() {
                     {t("headerDescription")}
                 </p>
 
-                <form ref={form} onSubmit={sendEmail} className="space-y-4">
-                    <input
-                        type="text"
-                        name="user_name"
-                        placeholder={t("placeholderName")}
-                        required
-                        className="w-full rounded-lg border border-hairline bg-surface p-3 outline-none transition-colors focus:border-primary"
-                    />
-                    <input
-                        type="email"
-                        name="user_email"
-                        placeholder={t("placeholderEmail")}
-                        required
-                        className="w-full rounded-lg border border-hairline bg-surface p-3 outline-none transition-colors focus:border-primary"
-                    />
-                    <textarea
-                        name="message"
-                        placeholder={t("placeholderMessage")}
-                        required
-                        rows={6}
-                        className="w-full rounded-lg border border-hairline bg-surface p-3 outline-none transition-colors focus:border-primary"
-                    />
-                    <button
-                        type="submit"
-                        className="cursor-pointer rounded-lg bg-ink px-7 py-3 font-semibold text-white transition-transform duration-500 hover:scale-105 hover:bg-ink-deep"
-                    >
-                        {t("submitButton")}
-                    </button>
-                </form>
+                <ContactForm />
             </div>
         </div>
     );

--- a/app/[locale]/(root)/results/loading.tsx
+++ b/app/[locale]/(root)/results/loading.tsx
@@ -1,0 +1,11 @@
+import { Loader2 } from "lucide-react";
+
+const Loading = () => {
+    return (
+        <div className="flex min-h-screen items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-gray-600" />
+        </div>
+    );
+};
+
+export default Loading;

--- a/app/[locale]/(root)/survey/loading.tsx
+++ b/app/[locale]/(root)/survey/loading.tsx
@@ -1,0 +1,11 @@
+import { Loader2 } from "lucide-react";
+
+const Loading = () => {
+    return (
+        <div className="flex min-h-screen items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-gray-600" />
+        </div>
+    );
+};
+
+export default Loading;

--- a/app/[locale]/admin/loading.tsx
+++ b/app/[locale]/admin/loading.tsx
@@ -1,0 +1,11 @@
+import { Loader2 } from "lucide-react";
+
+const Loading = () => {
+    return (
+        <div className="flex min-h-screen items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-gray-600" />
+        </div>
+    );
+};
+
+export default Loading;

--- a/components/admin/ManageLessonsClient.tsx
+++ b/components/admin/ManageLessonsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
     Card,
@@ -32,17 +32,14 @@ export default function ManageLessonsClient({
     initialLessons,
 }: ManageLessonsClientProps) {
     const [lessons, setLessons] = useState<LessonData[]>(initialLessons);
-    const [filteredLessons, setFilteredLessons] =
-        useState<LessonData[]>(initialLessons);
     const [searchTerm, setSearchTerm] = useState("");
     const [selectedDifficulty, setSelectedDifficulty] = useState("all");
     const [message, setMessage] = useState("");
 
-    useEffect(() => {
-        filterLessons();
-    }, [lessons, searchTerm, selectedDifficulty]);
-
-    const filterLessons = () => {
+    // Derived, not stored: recomputes when inputs change without the extra
+    // render cycle of the old state+effect pair. Copied before sort so the
+    // source array is never mutated.
+    const filteredLessons = useMemo(() => {
         let filtered = lessons;
 
         if (searchTerm) {
@@ -64,10 +61,8 @@ export default function ManageLessonsClient({
         }
 
         // Sort by lesson index
-        filtered.sort((a, b) => a.lessonIndex - b.lessonIndex);
-
-        setFilteredLessons(filtered);
-    };
+        return [...filtered].sort((a, b) => a.lessonIndex - b.lessonIndex);
+    }, [lessons, searchTerm, selectedDifficulty]);
 
     const handleDelete = async (lessonId: string, title: string) => {
         if (!confirm(`Are you sure you want to delete "${title}"?`)) {

--- a/components/contact/ContactForm.tsx
+++ b/components/contact/ContactForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useRef } from "react";
+import emailjs from "@emailjs/browser";
+import { useTranslations } from "next-intl";
+
+// The only part of the contact page that needs the browser: the emailjs SDK
+// and form handling live here so the page shell stays a server component
+export default function ContactForm() {
+    const form = useRef<HTMLFormElement>(null);
+    const t = useTranslations("contactUs");
+
+    const sendEmail = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!form.current) return;
+
+        emailjs
+            .sendForm(
+                process.env.NEXT_PUBLIC_EMAILJS_SERVICE_ID!,
+                process.env.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID!,
+                form.current,
+                process.env.NEXT_PUBLIC_EMAILJS_PUBLIC_KEY!,
+            )
+            .then(
+                () => {
+                    alert("Message sent! 🎉");
+                    form.current?.reset();
+                },
+                (error) => {
+                    alert("Failed to send. 😞");
+                    console.error(error);
+                },
+            );
+    };
+
+    return (
+        <form ref={form} onSubmit={sendEmail} className="space-y-4">
+            <input
+                type="text"
+                name="user_name"
+                placeholder={t("placeholderName")}
+                required
+                className="w-full rounded-lg border border-hairline bg-surface p-3 outline-none transition-colors focus:border-primary"
+            />
+            <input
+                type="email"
+                name="user_email"
+                placeholder={t("placeholderEmail")}
+                required
+                className="w-full rounded-lg border border-hairline bg-surface p-3 outline-none transition-colors focus:border-primary"
+            />
+            <textarea
+                name="message"
+                placeholder={t("placeholderMessage")}
+                required
+                rows={6}
+                className="w-full rounded-lg border border-hairline bg-surface p-3 outline-none transition-colors focus:border-primary"
+            />
+            <button
+                type="submit"
+                className="cursor-pointer rounded-lg bg-ink px-7 py-3 font-semibold text-white transition-transform duration-500 hover:scale-105 hover:bg-ink-deep"
+            >
+                {t("submitButton")}
+            </button>
+        </form>
+    );
+}

--- a/components/games/FocusGroupRun.tsx
+++ b/components/games/FocusGroupRun.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import GameTimer, { formatTime } from "./GameTimer";
 import { Button } from "@/components/ui/button";
 import PicturePanel from "@/components/games/PicturePanel";
 import { FREEZE_MS, REVEAL_AFTER_WRONG } from "@/constants/games/focusGroup";
@@ -17,13 +18,6 @@ function shuffle<T>(items: T[]): T[] {
         [result[i], result[j]] = [result[j], result[i]];
     }
     return result;
-}
-
-function formatTime(ms: number) {
-    const totalSeconds = Math.floor(ms / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 }
 
 type StageProps = {
@@ -459,7 +453,6 @@ export default function FocusGroupRun({
     const [phase, setPhase] = useState<RunPhase>("start");
     const [teamName, setTeamName] = useState("");
     const [stageIndex, setStageIndex] = useState(0);
-    const [elapsedMs, setElapsedMs] = useState(0);
     const [finalMs, setFinalMs] = useState(0);
     const [mistakes, setMistakes] = useState(0);
 
@@ -485,19 +478,8 @@ export default function FocusGroupRun({
         };
     }, []);
 
-    // The clock never stops — a freeze costs real seconds, and that is the
-    // whole penalty.
-    useEffect(() => {
-        if (phase !== "running") return;
-        const id = setInterval(() => {
-            setElapsedMs(Date.now() - startRef.current);
-        }, 250);
-        return () => clearInterval(id);
-    }, [phase]);
-
     const start = () => {
         startRef.current = Date.now();
-        setElapsedMs(0);
         setStageIndex(0);
         setMistakes(0);
         setStageWrong(0);
@@ -629,7 +611,14 @@ export default function FocusGroupRun({
                 </span>
                 <span className="flex items-center gap-1 text-lg font-bold tabular-nums text-foreground">
                     <Timer className="h-5 w-5" />
-                    {formatTime(elapsedMs)}
+                    {/* The clock never stops — a freeze costs real seconds,
+                        and that is the whole penalty. It ticks in its own leaf
+                        so it doesn't re-render the game tree. */}
+                    <GameTimer
+                        startTime={startRef.current}
+                        running={phase === "running"}
+                        intervalMs={250}
+                    />
                 </span>
             </div>
 

--- a/components/games/GameTimer.tsx
+++ b/components/games/GameTimer.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function formatTime(ms: number) {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+// Self-contained running clock. The interval lives in this leaf so the tick
+// re-renders a single text node instead of the whole game tree.
+const GameTimer = ({
+    startTime,
+    running,
+    intervalMs = 500,
+}: {
+    startTime: number;
+    running: boolean;
+    intervalMs?: number;
+}) => {
+    const [elapsedMs, setElapsedMs] = useState(0);
+
+    useEffect(() => {
+        if (!running) return;
+        setElapsedMs(Date.now() - startTime);
+        const id = setInterval(() => {
+            setElapsedMs(Date.now() - startTime);
+        }, intervalMs);
+        return () => clearInterval(id);
+    }, [running, startTime, intervalMs]);
+
+    return <>{formatTime(elapsedMs)}</>;
+};
+
+export default GameTimer;

--- a/components/games/WordMatchGame.tsx
+++ b/components/games/WordMatchGame.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
+import GameTimer, { formatTime } from "./GameTimer";
 import { Button } from "@/components/ui/button";
 import { MATCH_COOLDOWN_MS } from "@/constants/games/wordMatch";
 import {
@@ -65,13 +66,6 @@ function buildTiles(round: WordMatchGameRound): GameTile[] {
     return shuffle(tiles);
 }
 
-function formatTime(ms: number) {
-    const totalSeconds = Math.floor(ms / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-}
-
 function DifficultyBadge({ difficulty }: { difficulty: GameDifficulty }) {
     return (
         <span
@@ -95,7 +89,6 @@ export default function WordMatchGame({
     const [matchedPairs, setMatchedPairs] = useState<number[]>([]);
     const [wrongIds, setWrongIds] = useState<string[]>([]);
     const [wrongAttempts, setWrongAttempts] = useState(0);
-    const [elapsedMs, setElapsedMs] = useState(0);
     const [finalTimeMs, setFinalTimeMs] = useState(0);
     const [score, setScore] = useState(0);
 
@@ -117,15 +110,6 @@ export default function WordMatchGame({
     const category = categories.find((item) => item.id === categoryId);
     const hasNextRound = roundIndex + 1 < categoryRounds.length;
 
-    // Tick the visible timer while a round is being played
-    useEffect(() => {
-        if (phase !== "playing") return;
-        const interval = setInterval(() => {
-            setElapsedMs(Date.now() - startTimeRef.current);
-        }, 500);
-        return () => clearInterval(interval);
-    }, [phase]);
-
     useEffect(() => {
         return () => {
             if (wrongTimeoutRef.current) clearTimeout(wrongTimeoutRef.current);
@@ -146,7 +130,6 @@ export default function WordMatchGame({
         coolingRef.current = false;
         setWrongIds([]);
         setWrongAttempts(0);
-        setElapsedMs(0);
         startTimeRef.current = Date.now();
         setPhase("playing");
     };
@@ -371,7 +354,10 @@ export default function WordMatchGame({
                     </span>
                     <span className="flex items-center gap-1 tabular-nums">
                         <Timer className="h-4 w-4" />
-                        {formatTime(elapsedMs)}
+                        <GameTimer
+                            startTime={startTimeRef.current}
+                            running={phase === "playing"}
+                        />
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
## What changed

- fix the About page team-card image wrapper width
- move the EmailJS contact form into a client-only leaf component
- add loading fallbacks for results, survey, and admin routes
- move the Word Match and Focus Group clocks into a small timer leaf so ticks do not rerender the full game tree
- derive the admin lesson search results with `useMemo` instead of duplicated state and an effect

## Why

These are the small, independent pieces from a larger local performance pass. Keeping them separate makes them easier to review, test, merge, or revert without pulling in the higher-risk lesson, database, webhook, authentication, middleware, rate-limiter, and dependency changes.

## Impact

Public About and Contact behavior should remain the same, with the Contact page shipping less client-owned code. Dynamic routes gain a visible loading state. Game clock ticks update a leaf component instead of rerendering the entire game. Admin lesson filtering avoids an extra render cycle.

## Validation

- `git diff --check`
- `tsc --noEmit`
- full `npm run build` from an isolated clean worktree using the committed lockfile
- visual smoke check of the About team cards
- Contact form hydration smoke check: name, email, and message fields accepted input

## Manual checks before merge

- while signed in, start Word Match and one Focus Group game; confirm the timer advances and the final time is correct
- as an admin, verify lesson search, difficulty filtering, and sorting; do not delete live data for this smoke check
- optionally confirm the loading spinner appears during a cold navigation to Results, Survey, and Admin
