### PR TITLE
Stream lesson speech responses

### DIFF
--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,0 +1,128 @@
+import { auth } from "@clerk/nextjs/server";
+import mongoose from "mongoose";
+import OpenAI from "openai";
+import { connectToDatabase } from "@/lib/database";
+import LessonProgress from "@/lib/database/models/lessonProgress.model";
+import User from "@/lib/database/models/user.model";
+import { consumeTtsRateLimit } from "@/lib/ttsRateLimiter";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_TTS_INPUT_CHARS = 4096;
+
+let openaiClient: OpenAI | null = null;
+const getOpenAIClient = () => (openaiClient ??= new OpenAI());
+
+export async function GET(request: Request) {
+    const { userId: clerkUserId } = await auth();
+    if (!clerkUserId) {
+        return new Response("Unauthorized", { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const progressId = searchParams.get("progressId");
+    const messageIndexParam = searchParams.get("messageIndex");
+
+    if (!progressId || !mongoose.isValidObjectId(progressId)) {
+        return new Response("Invalid progressId", { status: 400 });
+    }
+
+    if (!messageIndexParam || !/^\d+$/.test(messageIndexParam)) {
+        return new Response("Invalid messageIndex", { status: 400 });
+    }
+
+    const messageIndex = Number(messageIndexParam);
+    if (!Number.isSafeInteger(messageIndex)) {
+        return new Response("Invalid messageIndex", { status: 400 });
+    }
+
+    let requestedMessage: Message | undefined;
+
+    try {
+        await connectToDatabase();
+
+        const user = await User.findOne({ clerkId: clerkUserId })
+            .select("_id")
+            .lean<{ _id: unknown }>();
+
+        if (!user) {
+            return new Response("Unknown user", { status: 403 });
+        }
+
+        // Read exactly the tutor message returned by the preceding Server
+        // Action. The progress ID and owner check prevent another user's text
+        // from being synthesized, while the exact index avoids cross-tab races.
+        const progress = await LessonProgress.findOne({
+            _id: progressId,
+            userId: user._id,
+        })
+            .select({ convoHistory: { $slice: [messageIndex, 1] } })
+            .lean<{ convoHistory?: Message[] }>();
+
+        requestedMessage = progress?.convoHistory?.[0];
+    } catch (error) {
+        console.error("Unable to prepare TTS request:", error);
+        return new Response("Speech service unavailable", { status: 503 });
+    }
+
+    if (
+        !requestedMessage ||
+        requestedMessage.role !== "System" ||
+        !requestedMessage.message.trim()
+    ) {
+        return new Response("No tutor reply to speak", { status: 404 });
+    }
+
+    try {
+        const rateLimit = await consumeTtsRateLimit(clerkUserId);
+        if (!rateLimit.allowed) {
+            return new Response("Too many requests", {
+                status: 429,
+                headers: {
+                    "Retry-After": rateLimit.retryAfterSeconds.toString(),
+                    "Cache-Control": "private, no-store, max-age=0",
+                },
+            });
+        }
+    } catch (error) {
+        console.error("Unable to check TTS rate limit:", error);
+        return new Response("Speech service unavailable", { status: 503 });
+    }
+
+    try {
+        const speech = await getOpenAIClient().audio.speech.create(
+            {
+                model: "gpt-4o-mini-tts",
+                voice: "shimmer",
+                input: requestedMessage.message.slice(0, MAX_TTS_INPUT_CHARS),
+                instructions:
+                    "Speak in an enthusiastic but calm and positive tone.",
+                response_format: "mp3",
+            },
+            { signal: request.signal },
+        );
+
+        if (!speech.body) {
+            return new Response("Speech synthesis failed", { status: 502 });
+        }
+
+        // Forward OpenAI's response body directly so playback can start before
+        // synthesis finishes. MP3 is also substantially smaller than the WAV
+        // that was previously base64-encoded inside the Server Action result.
+        return new Response(speech.body, {
+            headers: {
+                "Content-Type": "audio/mpeg",
+                "Cache-Control": "private, no-store, max-age=0",
+                "X-Content-Type-Options": "nosniff",
+            },
+        });
+    } catch (error) {
+        if (request.signal.aborted) {
+            return new Response(null, { status: 499 });
+        }
+
+        console.error("TTS synthesis failed:", error);
+        return new Response("Speech synthesis failed", { status: 502 });
+    }
+}

--- a/components/lesson/Lesson.tsx
+++ b/components/lesson/Lesson.tsx
@@ -57,8 +57,10 @@ const Lesson = ({ previousLessonProgress, lessonInfo }: LessonProps) => {
     // Function to stop the currently playing audio
     const stopAllAudio = () => {
         if (currentAudioRef.current) {
-            currentAudioRef.current.pause();
-            currentAudioRef.current.currentTime = 0;
+            const audio = currentAudioRef.current;
+            audio.pause();
+            audio.removeAttribute("src");
+            audio.load();
             currentAudioRef.current = null;
         }
     };
@@ -91,6 +93,18 @@ const Lesson = ({ previousLessonProgress, lessonInfo }: LessonProps) => {
         });
     };
 
+    const streamTutorReply = (
+        progress: LessonProgress,
+        messageIndex: number,
+    ) => {
+        const searchParams = new URLSearchParams({
+            progressId: progress._id,
+            messageIndex: messageIndex.toString(),
+        });
+
+        playAudioSafely(new Audio(`/api/tts?${searchParams.toString()}`));
+    };
+
     useEffect(() => {
         const handleInitialMessage = async () => {
             // if the lesson hasn't been started (no conversation history) and we haven't sent initial message yet
@@ -101,19 +115,12 @@ const Lesson = ({ previousLessonProgress, lessonInfo }: LessonProps) => {
                 initialMessageSentRef.current = true; // Prevent multiple calls
                 setIsLoading(true);
 
-                // server action that gets the audio from the user and processes it and sends it to gemini and openai for the response
+                // Generate and persist the tutor's initial text reply.
                 const result = await processInitialMessage({
                     lessonIndex: lessonProgress.lessonIndex,
                 });
 
                 if (result.success) {
-                    // Play audio only if we have audio response
-                    if (result.audioBase64) {
-                        const audioSrc = `data:audio/wav;base64,${result.audioBase64}`;
-                        const audio = new Audio(audioSrc);
-                        playAudioSafely(audio);
-                    }
-
                     // Update state with the authoritative server-side progress
                     if (result.updatedLessonProgress) {
                         const updated = result.updatedLessonProgress;
@@ -123,6 +130,10 @@ const Lesson = ({ previousLessonProgress, lessonInfo }: LessonProps) => {
                             objectivesMet: [...updated.objectivesMet],
                             convoHistory: [...updated.convoHistory],
                         }));
+
+                        if (result.ttsMessageIndex !== undefined) {
+                            streamTutorReply(updated, result.ttsMessageIndex);
+                        }
                     }
                 } else {
                     console.error("processInitialMessage failed:", result);
@@ -207,20 +218,13 @@ const Lesson = ({ previousLessonProgress, lessonInfo }: LessonProps) => {
                     );
                 }
 
-                // server action that gets the audio from the user and processes it and sends it to gemini and openai for the response
+                // Transcribe the student and persist the tutor's text reply.
                 const result = await processAudioMessage({
                     audioBase64: base64,
                     lessonIndex: lessonProgress.lessonIndex,
                 });
 
                 if (result.success) {
-                    // Play audio only if we have audio response
-                    if (result.audioBase64) {
-                        const audioSrc = `data:audio/wav;base64,${result.audioBase64}`;
-                        const audio = new Audio(audioSrc);
-                        playAudioSafely(audio);
-                    }
-
                     // Force state update with new object reference
                     if (result.updatedLessonProgress) {
                         const updated = result.updatedLessonProgress;
@@ -232,6 +236,10 @@ const Lesson = ({ previousLessonProgress, lessonInfo }: LessonProps) => {
                             // Ensure convoHistory is a new reference
                             convoHistory: [...updated.convoHistory],
                         }));
+
+                        if (result.ttsMessageIndex !== undefined) {
+                            streamTutorReply(updated, result.ttsMessageIndex);
+                        }
                     }
                 } else {
                     console.error("processAudioMessage failed:", result);

--- a/components/lesson/Lesson.tsx
+++ b/components/lesson/Lesson.tsx
@@ -390,6 +390,12 @@ const Lesson = ({ previousLessonProgress, lessonInfo }: LessonProps) => {
                                                     ) : (
                                                         <LessonMessages
                                                             convoHistory={lessonProgress.convoHistory}
+                                                            onPlayTutorMessage={(messageIndex) =>
+                                                                streamTutorReply(
+                                                                    lessonProgress,
+                                                                    messageIndex,
+                                                                )
+                                                            }
                                                         />
                                                     )}
                                                     {error && (

--- a/components/lesson/LessonMessages.tsx
+++ b/components/lesson/LessonMessages.tsx
@@ -1,11 +1,15 @@
 import React from "react";
-import { User, Bot } from "lucide-react";
+import { User, Bot, Volume2 } from "lucide-react";
 
 type LessonMessagesProps = {
     convoHistory: Message[];
+    onPlayTutorMessage: (messageIndex: number) => void;
 };
 
-const LessonMessages = ({ convoHistory }: LessonMessagesProps) => {
+const LessonMessages = ({
+    convoHistory,
+    onPlayTutorMessage,
+}: LessonMessagesProps) => {
     return (
         <div className="space-y-6">
             {convoHistory.map((message, index) => (
@@ -33,6 +37,17 @@ const LessonMessages = ({ convoHistory }: LessonMessagesProps) => {
                             >
                             {message.message}
                         </p>
+                        {message.role === "System" && (
+                            <button
+                                type="button"
+                                onClick={() => onPlayTutorMessage(index)}
+                                className="inline-flex items-center gap-2 rounded-full border border-primary/30 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+                                aria-label="Play tutor audio"
+                            >
+                                <Volume2 className="h-3.5 w-3.5" />
+                                Hear teacher
+                            </button>
+                        )}
                     </div>
                 </div>
             ))}

--- a/lib/actions/conversation.actions.ts
+++ b/lib/actions/conversation.actions.ts
@@ -1,6 +1,5 @@
 "use server";
 import { GoogleGenAI } from "@google/genai";
-import OpenAI from "openai";
 import { Type } from "@google/genai";
 import { generateInstructions } from "@/lib/utils";
 import {
@@ -8,11 +7,8 @@ import {
   updateLessonProgress,
 } from "@/lib/actions/LessonProgress.actions";
 
-// Module-level lazy singletons so each request reuses the same client (and
-// its keep-alive connection pool) instead of paying a fresh TLS handshake
-let openaiClient: OpenAI | null = null;
-const getOpenAIClient = () => (openaiClient ??= new OpenAI());
-
+// Module-level lazy singleton so each request reuses the same client (and its
+// keep-alive connection pool) instead of paying a fresh TLS handshake.
 let geminiClient: GoogleGenAI | null = null;
 const getGeminiClient = () =>
   (geminiClient ??= new GoogleGenAI({ apiKey: process.env.GEMINI_KEY }));
@@ -60,7 +56,6 @@ export async function getResponse(
   instructions: string,
   currentObjectivesMet: boolean[]
 ) {
-  const openai = getOpenAIClient();
   const ai = getGeminiClient();
 
   // Defining the function the model can call to update lesson objectives
@@ -191,20 +186,8 @@ export async function getResponse(
       };
     }
 
-    const verbalResponse = await openai.audio.speech.create({
-      model: "gpt-4o-mini-tts",
-      voice: "shimmer",
-      input: transcriptionSystem,
-      instructions: "Speak in an enthusiastic but calm and positive tone.",
-      response_format: "wav",
-    });
-
-    const audioBuffer = Buffer.from(await verbalResponse.arrayBuffer());
-    const audioBase64 = audioBuffer.toString("base64");
-
     return {
       success: true,
-      audioBase64Response: audioBase64,
       systemTranscription: transcriptionSystem,
       objectiveIndices: objectiveIndices,
     };
@@ -262,7 +245,6 @@ export async function getUserTranscription(audioUrlBase64: string) {
 }
 
 export async function getInitialResponse(instructions: string) {
-  const openai = getOpenAIClient();
   const ai = getGeminiClient();
 
   try {
@@ -284,19 +266,8 @@ export async function getInitialResponse(instructions: string) {
       };
     }
 
-    const verbalResponse = await openai.audio.speech.create({
-      model: "gpt-4o-mini-tts",
-      voice: "shimmer",
-      input: transcriptionSystem,
-      instructions: "Speak in an enthusiastic but calm and positive tone.",
-      response_format: "wav",
-    });
-
-    const audioBuffer = Buffer.from(await verbalResponse.arrayBuffer());
-    const audioBase64 = audioBuffer.toString("base64");
     return {
       success: true,
-      audioBase64Response: audioBase64,
       systemTranscription: transcriptionSystem,
     };
   } catch (error) {
@@ -316,7 +287,7 @@ export async function processInitialMessage({
 }): Promise<{
   success: boolean;
   error?: string;
-  audioBase64?: string;
+  ttsMessageIndex?: number;
   updatedLessonProgress?: LessonProgress;
 }> {
   try {
@@ -368,7 +339,7 @@ export async function processInitialMessage({
 
     return {
       success: true,
-      audioBase64: audioResponse.audioBase64Response,
+      ttsMessageIndex: updatedLessonProgress.convoHistory.length - 1,
       updatedLessonProgress: updatedLessonProgress,
     };
   } catch (error) {
@@ -380,7 +351,8 @@ export async function processInitialMessage({
   }
 }
 
-// gets the audio from the user and processes it and sends it to gemini and openai for the response
+// Processes the student's audio and persists the tutor's text response. Speech
+// is synthesized afterward by /api/tts so it can stream directly to the client.
 export async function processAudioMessage({
   audioBase64,
   lessonIndex,
@@ -391,7 +363,7 @@ export async function processAudioMessage({
   success: boolean;
   error?: string;
   errorType?: "transcription" | "response";
-  audioBase64?: string;
+  ttsMessageIndex?: number;
   updatedLessonProgress?: LessonProgress;
 }> {
   try {
@@ -475,10 +447,11 @@ export async function processAudioMessage({
       ],
     });
 
-    // output is the audio that can be played, and updated lessonProgress that will be used to update the state
+    // The client can render immediately from the persisted progress, then ask
+    // /api/tts to stream the exact System message just appended.
     return {
       success: true,
-      audioBase64: audioResponse.audioBase64Response,
+      ttsMessageIndex: updatedLessonProgress.convoHistory.length - 1,
       updatedLessonProgress: updatedLessonProgress,
     };
   } catch (error) {

--- a/lib/ttsRateLimiter.ts
+++ b/lib/ttsRateLimiter.ts
@@ -1,0 +1,74 @@
+import mongoose from "mongoose";
+import { connectToDatabase } from "@/lib/database";
+
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS_PER_WINDOW = 20;
+
+const ttsRateLimitSchema = new mongoose.Schema({
+    // Bucket keys use MongoDB's built-in unique _id index, so correctness does
+    // not depend on a separately-created application index.
+    _id: { type: String, required: true },
+    count: { type: Number, required: true, default: 0 },
+    expiresAt: { type: Date, required: true },
+});
+
+ttsRateLimitSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+const TtsRateLimit =
+    mongoose.models.TtsRateLimit ||
+    mongoose.model("TtsRateLimit", ttsRateLimitSchema);
+
+const isDuplicateKeyError = (error: unknown) =>
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: number }).code === 11000;
+
+export async function consumeTtsRateLimit(userId: string): Promise<{
+    allowed: boolean;
+    retryAfterSeconds: number;
+}> {
+    await connectToDatabase();
+
+    const now = Date.now();
+    const bucket = Math.floor(now / WINDOW_MS);
+    const windowEnd = (bucket + 1) * WINDOW_MS;
+    const bucketId = `${userId}:${bucket}`;
+    const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((windowEnd - now) / 1000),
+    );
+
+    const update = {
+        $inc: { count: 1 },
+        $setOnInsert: { expiresAt: new Date(windowEnd + WINDOW_MS) },
+    };
+
+    let document;
+    try {
+        document = await TtsRateLimit.findOneAndUpdate(
+            { _id: bucketId },
+            update,
+            { upsert: true, new: true },
+        );
+    } catch (error) {
+        if (!isDuplicateKeyError(error)) throw error;
+
+        // Two first requests can race the upsert. Once one creates the bucket,
+        // the loser retries as a plain atomic increment.
+        document = await TtsRateLimit.findOneAndUpdate(
+            { _id: bucketId },
+            { $inc: { count: 1 } },
+            { new: true },
+        );
+    }
+
+    if (!document) {
+        throw new Error("Failed to update the TTS rate-limit bucket");
+    }
+
+    return {
+        allowed: document.count <= MAX_REQUESTS_PER_WINDOW,
+        retryAfterSeconds,
+    };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -91,5 +91,8 @@ export const config = {
     matcher: [
         // Skip all internal paths (_next, _vercel) and API routes
         "/((?!api|_next|_vercel|.*\\..*).*)",
+        // The route handler performs its own authorization, but Clerk's
+        // middleware must run first so auth() has request context.
+        "/api/tts",
     ]
 };

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,6 +1,7 @@
 // LESSON TYPES
 
 declare type LessonProgress = {
+    _id: string;
     userId: string;
     lessonIndex: number;
     objectivesMet: boolean[];


### PR DESCRIPTION
## Summary

- return persisted tutor text from lesson Server Actions without buffering WAV audio or serializing base64
- stream MP3 speech from a dedicated authenticated `/api/tts` route
- authorize the exact lesson-progress owner and tutor-message index
- add a Mongo-backed 20-requests-per-minute TTS limit and stop active streams when playback is cancelled

## Why this should feel faster

The lesson UI can render the saved reply as soon as Gemini and MongoDB finish. Speech synthesis then travels as a direct MP3 stream, so playback can begin before the whole audio response is buffered and the Server Action no longer carries a large base64 WAV payload.

## Validation

- `npm run build`
- production-mode unauthenticated request to `/api/tts` returns `401 Unauthorized`
- browser smoke test of the production build
- `git diff --check`

## Manual check before merge

- [ ] Sign in and open a lesson with no existing conversation; confirm the initial tutor text appears and speech starts
- [ ] Record one response; confirm the new tutor text appears, speech starts, and starting another recording stops the current speech
- [ ] In DevTools Network, confirm `/api/tts` returns `200` with `Content-Type: audio/mpeg`
